### PR TITLE
Further revisions to ALB support

### DIFF
--- a/lib/capify-ec2.rb
+++ b/lib/capify-ec2.rb
@@ -32,7 +32,6 @@ class CapifyEc2
 
     # Open connections to AWS with the SDK
     alb_client = Aws::ElasticLoadBalancingV2::Client.new(region: 'eu-west-1')
-    ec2_client = Aws::EC2::Client.new(region: 'eu-west-1')
 
     # Maintain backward compatibility with previous config format
     @ec2_config[:project_tags] ||= []
@@ -439,8 +438,6 @@ class CapifyEc2
         end
     end
   reregistered_target_groups
-
-    end
   end
 
   def reregister_instance_with_elb_by_dns(server_dns, load_balancer, timeout)

--- a/lib/capify-ec2.rb
+++ b/lib/capify-ec2.rb
@@ -432,9 +432,6 @@ class CapifyEc2
         puts "[Capify-EC2] Skipping non-VPC instance '#{server_dns}' ('#{instance}') from target group '#{target_group}'..."
         return []
     end
-
-    # Sleep, but why?
-    sleep 10
     
     puts "[Capify-EC2] Re-registering instance with ALB target group '#{target_group}'..."
 
@@ -473,8 +470,6 @@ class CapifyEc2
         puts "[Capify-EC2] Skipping VPC instance '#{server_dns}' ('#{instance}') from ELB registration..."
         return []
     end
-
-    sleep 10
 
     puts "[Capify-EC2] Re-registering instance with ELB '#{load_balancer.id}'..."
     result = elb.register_instances_with_load_balancer(instance.id, load_balancer.id)


### PR DESCRIPTION
This PR fleshes out the stub methods and actually attempts to register/deregister instances to target groups. It requires the Ruby deployment scripts to be extended with `:target_group_names` entries as appropriate.