### PR TITLE
Restore deregistration healthcheck

### DIFF
--- a/lib/capify-ec2.rb
+++ b/lib/capify-ec2.rb
@@ -354,7 +354,7 @@ class CapifyEc2
 
       # Loop until instance is deregistered or timeout is reached
       begin
-        Timeout::timeout(options[:timeout]) do
+        Timeout::timeout(5]) do
           begin
             # Verify the instance is no longer in the target group
             response = @alb_client.describe_target_health({

--- a/lib/capify-ec2.rb
+++ b/lib/capify-ec2.rb
@@ -357,7 +357,7 @@ class CapifyEc2
         Timeout::timeout(options[:timeout]) do
           begin
             # Verify the instance is no longer in the target group
-            response = alb_client.describe_target_health({
+            response = @alb_client.describe_target_health({
               target_group_arn: target_group_arn,
               targets: [ { id: instance.id } ]
             })
@@ -383,7 +383,7 @@ class CapifyEc2
 
       rescue Timeout::Error
         # Instance failed to reach unused state within the timeout
-        puts "[Capify-EC2] Failed to remove '#{server_dns}' ('#{instance}') from target group '#{target_group}'"
+        puts "[Capify-EC2] Failed to remove '#{server_dns}' ('#{instance.id}') from target group '#{target_group}'"
         puts "[Capify-EC2] Instance is in state '#{response.target_health_descriptions[0].target_health.state}' with description:"
         puts "[Capify-EC2] #{response.target_health_descriptions[0].target_health.description}"
       end


### PR DESCRIPTION
This PR restores the deregistration healthcheck. It also permits deployment to instances that still have active connections and are in the draining state. The risk involved here has been discussed and deemed acceptable as per the conversation in the #mentionme-shared Slack channel.